### PR TITLE
feat: support config entries on topic creation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -279,6 +279,9 @@
       {{ kafka_home }}/bin/kafka-topics.sh --create --bootstrap-server localhost:9092 --topic {{ item.name }}
       --partitions {{ item.partitions | default(1) }}
       --replication-factor {{ item.replication_factor | default(1) }}
+      {% for k,v in item.config | dictsort %}
+      --config {{ k | replace("_","." )}}={{ v }}
+      {% endfor %}
   when: item.name not in kafka__reg_topics.stdout_lines
   loop: "{{ kafka_topics }}"
   changed_when: true


### PR DESCRIPTION
This pr adds support for topic configuration on create minor addition of template to the role to turn a dict where "." has been replaced with "_" into --config options on the cli during create